### PR TITLE
deps: have dependabot update composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       - dependency-type: "all"
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directores:
+    - "/"
+    - ".github/actions/*"
     schedule:
       interval: daily


### PR DESCRIPTION
This updates dependabot.yml to also look into ./github/actions/*

Support for this was recently introduced, see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--