### PR TITLE
fix(deps): have dependabot update composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       - dependency-type: "all"
 
   - package-ecosystem: github-actions
-    directores:
+    directories:
     - "/"
     - ".github/actions/*"
     schedule:


### PR DESCRIPTION
Followup to #99, that wasn't working because of a typo.