### PR TITLE
feat!(ci): Remove arm/v7 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN --mount=type=cache,target=target \
     target=$(case "$TARGETARCH" in \
         amd64) echo x86_64-unknown-linux-musl ;; \
         arm64) echo aarch64-unknown-linux-musl ;; \
-        arm) echo armv7-unknown-linux-musleabihf ;; \
         *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac) && \
     just-cargo profile=$BUILD_TYPE target=$target build --package=linkerd-extension-init && \

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
-    { triple = "armv7-unknown-linux-gnu" },
 ]
 
 [advisories]

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ rs-features := 'all'
 
 _cargo := "cargo" + if rs-toolchain != "" { " +" + rs-toolchain } else { "" }
 
-archs := 'linux/amd64,linux/arm64,linux/arm/v7'
+archs := 'linux/amd64,linux/arm64'
 
 # Check that the Rust code is formatted correctly.
 rs-check-fmt:


### PR DESCRIPTION
This architecture has become too significant of a maintenance burden, and isn't used often enough to justify the associated maintenance cost.

This removes arm/v7 from all the build infrastructure/dockerfiles/etc. Note that arm64 targets are still widely used and well supported.

Related: https://github.com/linkerd/linkerd2/pull/14308