### PR TITLE
refactor(deps): use linkerd-kubert git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,8 +752,7 @@ dependencies = [
 [[package]]
 name = "kubert"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9f0a6d5aea62e120a6875be7d06f74c2ff4e8f33c40cfc331b4adee2f93a76"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.25.0#a2ff424f072a0de77d98ab97592d6f66ae1d9546"
 dependencies = [
  "kube-client",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/linkerd/linkerd-extension-init"
 anyhow = "1"
 json-patch = "4"
 jsonptr = "0.7"
-kubert = { version = "0.25", features = ["log", "rustls-tls"] }
 rustls = { version = "0.23.40", default-features = false, features = ["aws-lc-rs"] }
 serde = "1"
 serde_json = "1"
@@ -29,6 +28,12 @@ features = ["derive", "help", "usage", "env", "std"]
 version = "1.1"
 default-features = false
 features = ["client", "jsonpatch", "rustls-tls"]
+
+[dependencies.kubert]
+version = "0.25"
+features = ["log", "rustls-tls"]
+git = "https://github.com/linkerd/linkerd-kubert.git"
+tag = "kubert/v0.25.0"
 
 [dependencies.k8s-openapi]
 version = "0.25"

--- a/deny.toml
+++ b/deny.toml
@@ -62,7 +62,10 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = [
+    # We accept a git dependency upon linkerd-kubert.
+    "https://github.com/linkerd/linkerd-kubert.git"
+]
 
 [sources.allow-org]
 github = []


### PR DESCRIPTION
see <https://github.com/linkerd/linkerd-kubert>.

we now have a fork of the kubert library. at the time of writing, this
is a 1:1 fork with no additional changes included. soon, we will
introduce some additional changes so that we can (1) pull in changes
like linkerd/linkerd-kubert@b27f147 that migrate away from abandoned
dependencies, and (2) update dependencies so that we can update our
gateway api bindings.

as an initial step towards this tasks, we alter our dependency upon
`kubert` so that it points to our new git repository.

* linkerd/linkerd2#15433
* linkerd/linkerd2-proxy#4583

Signed-off-by: katelyn martin <git@katelyn.world>
